### PR TITLE
✨post views 컬럼 추가 및 조회수 증가 기능

### DIFF
--- a/src/main/java/com/ci/Cruming/post/controller/PostController.java
+++ b/src/main/java/com/ci/Cruming/post/controller/PostController.java
@@ -91,4 +91,10 @@ public class PostController {
         return ResponseEntity.ok().body(postResponse);
     }
 
+    @PostMapping("/{postId}/views")
+    @Operation(summary = "게시글 조회수 증가", description = "게시글의 조회수를 1 증가 시킵니다. (프론트에서 무한 새로고침으로 조회수 증가 방지)")
+    public ResponseEntity<Void> increasePostView(@PathVariable Long postId) {
+        postService.increasePostView(postId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/ci/Cruming/post/dto/PostResponse.java
+++ b/src/main/java/com/ci/Cruming/post/dto/PostResponse.java
@@ -24,7 +24,8 @@ public record PostResponse(
         List<FileResponse> files,
         boolean isLiked,
         Long likeCount,
-        Long replyCount
+        Long replyCount,
+        Long views
 ) {
 
 }

--- a/src/main/java/com/ci/Cruming/post/dto/mapper/PostMapper.java
+++ b/src/main/java/com/ci/Cruming/post/dto/mapper/PostMapper.java
@@ -24,6 +24,7 @@ public class PostMapper {
                 .content(request.content())
                 .category(Category.GENERAL)
                 .visibility(Visibility.PUBLIC)
+                .views(0L)
                 .build();
     }
 
@@ -36,6 +37,7 @@ public class PostMapper {
                 .title(request.title())
                 .content(request.content())
                 .visibility(Visibility.PUBLIC)
+                .views(0L)
                 .build();
     }
 

--- a/src/main/java/com/ci/Cruming/post/dto/mapper/PostMapper.java
+++ b/src/main/java/com/ci/Cruming/post/dto/mapper/PostMapper.java
@@ -73,7 +73,8 @@ public class PostMapper {
                 files,
                 isLiked,
                 likeCount,
-                replyCount
+                replyCount,
+                post.getViews()
         );
     }
 

--- a/src/main/java/com/ci/Cruming/post/entity/Post.java
+++ b/src/main/java/com/ci/Cruming/post/entity/Post.java
@@ -56,6 +56,9 @@ public class Post {
     @Column(nullable = false)
     private Visibility visibility;
 
+    @Column(nullable = false, columnDefinition = "bigint default 0")
+    private Long views;
+
     @CreatedDate
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
@@ -86,4 +89,7 @@ public class Post {
         this.location = location;
     }
 
+    public void incrementViews() {
+        this.views++;
+    }
 }

--- a/src/main/java/com/ci/Cruming/post/service/PostService.java
+++ b/src/main/java/com/ci/Cruming/post/service/PostService.java
@@ -125,4 +125,10 @@ public class PostService {
         return postRepository.findById(postId)
                 .orElseThrow(() -> new CrumingException(ErrorCode.POST_NOT_FOUND));
     }
+
+    @Transactional
+    public void increasePostView(Long postId) {
+        Post post = postRepository.getReferenceById(postId);
+        post.incrementViews();
+    }
 }


### PR DESCRIPTION
새로고침으로 인한 조회수 중복 증가 문제를 localStorage를 활용하여 임시적으로 해결하였습니다.
- 30분 이내 재조회 시 조회수가 증가하지 않도록 처리
- localStorage에 마지막 조회 시간을 저장하여 관리